### PR TITLE
confiure.in: modernize the AM_INIT_AUTOMAKE

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1,6 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT(main.c)
-AM_INIT_AUTOMAKE(ffsb, 6.0-RC2)
+AC_INIT(ffsb, 6.0-RC2)
+AC_CONFIG_SRCDIR([main.c])
+AM_INIT_AUTOMAKE
 
 AM_CONFIG_HEADER(config.h)
 AC_CANONICAL_HOST

--- a/fh.h
+++ b/fh.h
@@ -19,6 +19,7 @@
 #define _FH_H_
 
 #include <inttypes.h>
+#include "ffsb.h"
 
 struct ffsb_thread;
 struct ffsb_fs;
@@ -37,5 +38,6 @@ void fhclose(int, struct ffsb_thread *, struct ffsb_fs *);
 
 int writefile_helper(int, uint64_t, uint32_t, char *, struct ffsb_thread *,
 		     struct ffsb_fs *);
+void fhstat(char *name, ffsb_thread_t *ft, ffsb_fs_t *fs);
 
 #endif /* _FH_H_ */

--- a/parser.c
+++ b/parser.c
@@ -203,7 +203,7 @@ static char *get_optstr(char *buf, char string[])
 	len = strnlen(string, BUFSIZE);
 	sprintf(search_str, "%s=%%%ds\\n", string, BUFSIZE - len-1);
 	if (1 == sscanf(line, search_str, &temp)) {
-		len = strnlen(temp, 4096);
+		len = strnlen(temp, 4095) + 1;
 		ret_buf = malloc(len);
 		strncpy(ret_buf, temp, len);
 		return ret_buf;


### PR DESCRIPTION
The form of AM_INIT_AUTOMAKE(PACKAGE, VERSION, [NO-DEFINE]) has
been deprecated, we need to modernize it in new form.

Fixes: https://tracker.ceph.com/issues/48365
Signed-off-by: Xiubo Li <xiubli@redhat.com>