### PR TITLE
Revert "Exit FFSB if filesystem can't be reused.

### DIFF
--- a/ffsb_fs.c
+++ b/ffsb_fs.c
@@ -171,7 +171,7 @@ void *construct_ffsb_fs(void *data)
 		printf("checking existing fs: %s\n", fs->basedir);
 		ret = check_existing_fileset(fs);
 		if (ret == NULL) {
-            fprintf(stderr, "Can not reuse filesystem\n");
+            fprintf(stderr, "Can not reuse filesystem");
             exit(1);
 		}
 	} else {

--- a/ffsb_fs.c
+++ b/ffsb_fs.c
@@ -171,8 +171,8 @@ void *construct_ffsb_fs(void *data)
 		printf("checking existing fs: %s\n", fs->basedir);
 		ret = check_existing_fileset(fs);
 		if (ret == NULL) {
-            fprintf(stderr, "Can not reuse filesystem");
-            exit(1);
+			printf("recreating new fileset\n");
+			ret = construct_new_fileset(fs);
 		}
 	} else {
 		printf("creating new fileset %s\n", fs->basedir);


### PR DESCRIPTION
This change blocked us for the multiple ffsb tests because if the first test specifies the `reuse` flag it will fail directly and couldn't find any existing data/meta files from previous test.

Let's revert it and try to create the first fileset for the first test.